### PR TITLE
Increase the linting threshold

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -91,7 +91,7 @@ jobs:
       # Next step: run pylint. Anything less than 10/10 will fail.
       - name: Lint with pylint
         run: |
-          pylint --fail-under=8 WisconsinWolfAnalysis/*.py
+          pylint --fail-under=9.9 WisconsinWolfAnalysis/*.py
       # Next step: run the unit tests with code coverage.
       - name: Unit tests
         run: |


### PR DESCRIPTION
Pylint doesn't like the naming of our project, which prevents us from getting a 10/10. Current code is 9.94, this updates the threshold to 9.9 to ensure we don't drop down just by deleting code.